### PR TITLE
Fix embedded UI tab ordering, graph navigation, and editor button crash

### DIFF
--- a/lib/clarity/components/tree_component/render_node.html.heex
+++ b/lib/clarity/components/tree_component/render_node.html.heex
@@ -8,11 +8,7 @@
     phx-target={@myself}
     class="select-none"
   >
-    <summary
-      phx-click="toggle"
-      phx-value-vertex_id={Vertex.id(@vertex)}
-      phx-target={@myself}
-    >
+    <summary>
       <.link
         patch={Path.join([@prefix, @lens.id, Vertex.id(@vertex)])}
         class={

--- a/lib/clarity/content.ex
+++ b/lib/clarity/content.ex
@@ -95,11 +95,21 @@ defmodule Clarity.Content do
           provider: provider(),
           live_view?: boolean(),
           live_component?: boolean(),
-          render_static: rendered_static_content() | nil
+          render_static: rendered_static_content() | nil,
+          sort_priority: integer()
         }
 
   @enforce_keys [:id, :name, :provider, :live_view?, :live_component?]
-  defstruct [:id, :name, :description, :provider, :live_view?, :live_component?, :render_static]
+  defstruct [
+    :id,
+    :name,
+    :description,
+    :provider,
+    :live_view?,
+    :live_component?,
+    :render_static,
+    sort_priority: 0
+  ]
 
   @doc """
   Returns the name of this content provider.
@@ -132,7 +142,16 @@ defmodule Clarity.Content do
   """
   @callback render_static(vertex :: Vertex.t(), lens :: Lens.t()) :: static_content()
 
-  @optional_callbacks [render_static: 2]
+  @doc """
+  Returns the sort priority for this content provider.
+
+  Lower values sort first. The default is `0`. Use negative values to sort
+  before other content (e.g., overview tabs), and positive values to sort
+  after (e.g., graph navigation).
+  """
+  @callback sort_priority() :: integer()
+
+  @optional_callbacks [render_static: 2, sort_priority: 0]
 
   @doc false
   @spec get_contents_for_vertex(Vertex.t(), Lens.t()) :: [t()]
@@ -168,6 +187,11 @@ defmodule Clarity.Content do
         normalize_static_content(provider.render_static(vertex, lens))
       end
 
+    sort_priority =
+      if function_exported?(provider, :sort_priority, 0),
+        do: provider.sort_priority(),
+        else: 0
+
     %__MODULE__{
       id: content_id(provider),
       name: provider.name(),
@@ -175,7 +199,8 @@ defmodule Clarity.Content do
       provider: provider,
       live_view?: live_view?,
       live_component?: live_component?,
-      render_static: render_static
+      render_static: render_static,
+      sort_priority: sort_priority
     }
   end
 

--- a/lib/clarity/content.ex
+++ b/lib/clarity/content.ex
@@ -213,8 +213,9 @@ defmodule Clarity.Content do
     {type, content}
   end
 
+  @doc false
   @spec content_id(module()) :: String.t()
-  defp content_id(provider) do
+  def content_id(provider) do
     provider
     |> Macro.underscore()
     |> String.replace(~r/[_\/]+/, "-")

--- a/lib/clarity/content/ash/action_overview.ex
+++ b/lib/clarity/content/ash/action_overview.ex
@@ -22,6 +22,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash action"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Action{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/aggregate_overview.ex
+++ b/lib/clarity/content/ash/aggregate_overview.ex
@@ -23,6 +23,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash aggregate"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Aggregate{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/application_overview.ex
+++ b/lib/clarity/content/ash/application_overview.ex
@@ -18,6 +18,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Ash domains and resources defined in this application"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Application{app: app}, _lens) do
       Ash.Info.domains(app) != []
     end

--- a/lib/clarity/content/ash/attribute_overview.ex
+++ b/lib/clarity/content/ash/attribute_overview.ex
@@ -21,6 +21,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash attribute"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Attribute{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/calculation_overview.ex
+++ b/lib/clarity/content/ash/calculation_overview.ex
@@ -21,6 +21,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash calculation"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Calculation{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/domain_overview.ex
+++ b/lib/clarity/content/ash/domain_overview.ex
@@ -19,6 +19,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash domain"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Domain{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/policy_overview.ex
+++ b/lib/clarity/content/ash/policy_overview.ex
@@ -21,6 +21,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash policy"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Policy{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/relationship_overview.ex
+++ b/lib/clarity/content/ash/relationship_overview.ex
@@ -21,6 +21,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash relationship"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Relationship{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/ash/resource_overview.ex
+++ b/lib/clarity/content/ash/resource_overview.ex
@@ -22,6 +22,9 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
     def description, do: "Overview of this Ash resource"
 
     @impl Clarity.Content
+    def sort_priority, do: -100
+
+    @impl Clarity.Content
     def applies?(%Resource{}, _lens), do: true
     def applies?(_vertex, _lens), do: false
 

--- a/lib/clarity/content/graph.ex
+++ b/lib/clarity/content/graph.ex
@@ -19,6 +19,9 @@ defmodule Clarity.Content.Graph do
   def description, do: "Visual graph navigation and exploration"
 
   @impl Clarity.Content
+  def sort_priority, do: 100
+
+  @impl Clarity.Content
   def applies?(_vertex, _lens), do: true
 
   @impl Clarity.Content

--- a/lib/clarity/open_editor.ex
+++ b/lib/clarity/open_editor.ex
@@ -161,6 +161,8 @@ defmodule Clarity.OpenEditor do
       {error_output, exit_code} ->
         {:error, {:command_failed, exit_code, error_output}}
     end
+  rescue
+    e -> {:error, {:system_error, e}}
   end
 
   defp execute_system_command([editor | args]) do
@@ -171,6 +173,8 @@ defmodule Clarity.OpenEditor do
       {error_output, exit_code} ->
         {:error, {:command_failed, exit_code, error_output}}
     end
+  rescue
+    e -> {:error, {:system_error, e}}
   end
 
   @spec get_relative_path_for_source_location(Clarity.SourceLocation.t()) ::

--- a/lib/clarity/pages/page_live.ex
+++ b/lib/clarity/pages/page_live.ex
@@ -284,8 +284,12 @@ defmodule Clarity.PageLive do
 
   @impl Phoenix.LiveView
   def handle_event("viz:click", %{"id" => id}, socket) do
+    graph_content_id = Content.content_id(Content.Graph)
+
     {:noreply,
-     push_patch(socket, to: Path.join([socket.assigns.prefix, socket.assigns.lens.id, id]))}
+     push_patch(socket,
+       to: Path.join([socket.assigns.prefix, socket.assigns.lens.id, id, graph_content_id])
+     )}
   end
 
   def handle_event("toggle_navigation", _params, socket) do

--- a/lib/clarity/perspective/lens.ex
+++ b/lib/clarity/perspective/lens.ex
@@ -36,16 +36,21 @@ defmodule Clarity.Perspective.Lens do
   ]
 
   @doc """
-  Default content sorter that sorts alphabetically by content name, with Graph deprioritized.
+  Default content sorter that sorts by priority, then alphabetically by name,
+  then by id for deterministic ordering.
 
   This is the default sorting function used by lenses unless they specify
-  their own content_sorter function. Graph content is moved to the end.
+  their own content_sorter function. Content providers can implement the
+  `sort_priority/0` callback to control their position (lower values first).
   """
   @spec sort_alphabetically(Content.t(), Content.t()) :: boolean()
-  def sort_alphabetically(a, b)
-  def sort_alphabetically(%Content{provider: Content.Graph}, _b), do: false
-  def sort_alphabetically(_a, %Content{provider: Content.Graph}), do: true
-  def sort_alphabetically(a, b), do: a.name <= b.name
+  def sort_alphabetically(a, b) do
+    cond do
+      a.sort_priority != b.sort_priority -> a.sort_priority < b.sort_priority
+      a.name != b.name -> a.name <= b.name
+      true -> a.id <= b.id
+    end
+  end
 
   @doc """
   Default vertex type filter that shows all vertex types.

--- a/test/clarity/content_test.exs
+++ b/test/clarity/content_test.exs
@@ -256,6 +256,39 @@ defmodule Clarity.ContentTest do
       assert render_fn.(%{}) == "Test content"
     end
 
+    test "includes sort_priority from provider callback", %{vertex: vertex, lens: lens} do
+      defmodule PriorityProvider do
+        @moduledoc false
+        @behaviour Content
+
+        @impl Content
+        def name, do: "Priority Content"
+        @impl Content
+        def description, do: nil
+        @impl Content
+        def sort_priority, do: -50
+        @impl Content
+        def applies?(%Root{}, _lens), do: true
+        def applies?(_vertex, _lens), do: false
+        @impl Content
+        def render_static(_vertex, _lens), do: {:markdown, "X"}
+      end
+
+      providers = [PriorityProvider]
+      Application.put_env(:clarity, :clarity_content_providers, providers)
+
+      [content] = Content.get_contents_for_vertex(vertex, lens)
+      assert content.sort_priority == -50
+    end
+
+    test "defaults sort_priority to 0 when callback not implemented", %{vertex: vertex, lens: lens} do
+      providers = [TestContentProvider]
+      Application.put_env(:clarity, :clarity_content_providers, providers)
+
+      [content] = Content.get_contents_for_vertex(vertex, lens)
+      assert content.sort_priority == 0
+    end
+
     test "handles providers without description callback", %{vertex: vertex, lens: lens} do
       defmodule NoDescProvider do
         @moduledoc false

--- a/test/clarity/open_editor_test.exs
+++ b/test/clarity/open_editor_test.exs
@@ -132,6 +132,22 @@ defmodule Clarity.OpenEditorTest do
       assert {:execute, execute_fn} = OpenEditor.action(source_location)
       assert {:error, _reason} = execute_fn.()
     end
+
+    test "execute function returns error when editor binary does not exist" do
+      Application.put_env(:clarity, :editor, "nonexistent_editor_binary_12345")
+      source_location = SourceLocation.from_path(:test_app, "/path/to/file.ex")
+
+      assert {:execute, execute_fn} = OpenEditor.action(source_location)
+      assert {:error, _reason} = execute_fn.()
+    end
+
+    test "execute function returns error when editor with template vars binary does not exist" do
+      Application.put_env(:clarity, :editor, "nonexistent_editor_12345 __FILE__:__LINE__")
+      source_location = SourceLocation.from_path(:test_app, "/path/to/file.ex")
+
+      assert {:execute, execute_fn} = OpenEditor.action(source_location)
+      assert {:error, _reason} = execute_fn.()
+    end
   end
 
   describe "configuration priority" do

--- a/test/clarity/perspective/lens_test.exs
+++ b/test/clarity/perspective/lens_test.exs
@@ -79,6 +79,63 @@ defmodule Clarity.Perspective.LensTest do
     end
   end
 
+  describe "sort_alphabetically/2" do
+    alias Clarity.Content
+
+    defp content(name, opts \\ []) do
+      id = Keyword.get(opts, :id, name)
+      priority = Keyword.get(opts, :sort_priority, 0)
+
+      %Content{
+        id: id,
+        name: name,
+        provider: Module.concat(["Test", name]),
+        live_view?: false,
+        live_component?: false,
+        sort_priority: priority
+      }
+    end
+
+    test "sorts by sort_priority first (lower values first)" do
+      high = content("Z Content", sort_priority: -100)
+      low = content("A Content", sort_priority: 100)
+      mid = content("M Content", sort_priority: 0)
+
+      sorted = Enum.sort([low, mid, high], &Lens.sort_alphabetically/2)
+
+      assert [^high, ^mid, ^low] = sorted
+    end
+
+    test "sorts alphabetically by name within same priority" do
+      z = content("Z Content")
+      a = content("A Content")
+      m = content("M Content")
+
+      sorted = Enum.sort([z, a, m], &Lens.sort_alphabetically/2)
+
+      assert [^a, ^m, ^z] = sorted
+    end
+
+    test "breaks ties by id for deterministic ordering" do
+      first = content("Same Name", id: "aaa")
+      second = content("Same Name", id: "zzz")
+
+      sorted = Enum.sort([second, first], &Lens.sort_alphabetically/2)
+
+      assert [^first, ^second] = sorted
+    end
+
+    test "overview content sorts before regular content" do
+      overview = content("Resource Overview", sort_priority: -100)
+      regular = content("Module Documentation")
+      graph = content("Graph Navigation", sort_priority: 100)
+
+      sorted = Enum.sort([graph, regular, overview], &Lens.sort_alphabetically/2)
+
+      assert [^overview, ^regular, ^graph] = sorted
+    end
+  end
+
   describe "show_vertex_types function" do
     test "show_vertex_types returns all types by default" do
       lens = %Lens{


### PR DESCRIPTION
## Summary
- Add `sort_priority` callback to content providers for deterministic tab ordering — overview tabs always first, Graph Navigation always last, with id-based tiebreaking
- Fix graph node clicks to stay on Graph Navigation tab instead of redirecting to default tab
- Fix editor button crash when configured editor binary doesn't exist (`System.cmd` `:enoent`)

## Testing
- [ ] Navigate to a resource — Resource Overview should be the first/default tab
- [ ] Tab order should be consistent across page loads
- [ ] Click a node in Graph Navigation — should open that node's Graph Navigation tab
- [ ] Set `EDITOR=nonexistent_binary` and click the editor button — should show error flash, not crash
- [ ] Verify Debug lens still shows Graph Navigation first