### PR TITLE
fix: suppress inline code backticks via tailwind config

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -19,12 +19,6 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
-
-  /* Remove backtick characters added by Tailwind Typography around inline code */
-  .prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before,
-  .prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
-    content: none;
-  }
 }
 
 /* Alerts and form errors used by phx.new */

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -13,6 +13,14 @@ module.exports = {
   ],
   theme: {
     extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            'code::before': { content: 'none' },
+            'code::after': { content: 'none' },
+          }
+        }
+      },
       animation: {
         'gradient': 'gradient 8s linear infinite',
         'float': 'float 7s ease-in-out infinite',

--- a/lib/clarity/components/markdown_component.ex
+++ b/lib/clarity/components/markdown_component.ex
@@ -53,6 +53,7 @@ defmodule Clarity.Components.MarkdownComponent do
         ast
         |> Earmark.Transform.map_ast(&transform_vertex_links(&1, prefix, lens))
         |> Earmark.Transform.map_ast(&transform_code_blocks/1)
+        |> transform_inline_code_in_ast()
         |> Earmark.Transform.transform()
 
       {:error, _reason, _messages} ->
@@ -115,6 +116,25 @@ defmodule Clarity.Components.MarkdownComponent do
   end
 
   defp transform_code_blocks(node), do: node
+
+  @spec transform_inline_code_in_ast(ast :: list()) :: list()
+  defp transform_inline_code_in_ast(ast) when is_list(ast) do
+    Enum.map(ast, &transform_inline_code_node/1)
+  end
+
+  @spec transform_inline_code_node(node :: Earmark.Parser.ast_node() | binary()) ::
+          Earmark.Parser.ast_node() | binary()
+  defp transform_inline_code_node({"pre", _, _, _} = node), do: node
+
+  defp transform_inline_code_node({"code", _attrs, content, meta}) do
+    {"strong", [{"class", "font-mono"}], content, meta}
+  end
+
+  defp transform_inline_code_node({tag, attrs, children, meta}) do
+    {tag, attrs, transform_inline_code_in_ast(children), meta}
+  end
+
+  defp transform_inline_code_node(other), do: other
 
   @spec extract_language(attrs :: list()) :: String.t() | nil
   defp extract_language(attrs) do

--- a/lib/clarity/components/tooltip_component.ex
+++ b/lib/clarity/components/tooltip_component.ex
@@ -26,11 +26,11 @@ defmodule Clarity.TooltipComponent do
     socket = assign(socket, assigns)
 
     # Only reset stream when breadcrumbs change to avoid DOM churn
-    if old_breadcrumbs != assigns[:breadcrumbs] do
+    if old_breadcrumbs == assigns[:breadcrumbs] do
+      {:ok, socket}
+    else
       preload_vertices = compute_preload_vertices(socket.assigns)
       {:ok, stream(socket, :tooltips, preload_vertices, reset: true)}
-    else
-      {:ok, socket}
     end
   end
 

--- a/lib/clarity/content/ash/action_overview.ex
+++ b/lib/clarity/content/ash/action_overview.ex
@@ -178,9 +178,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Arguments\n\n",
           "| Name | Type | Description | Required | Allow Nil |\n",
           "| --- | --- | --- | --- | --- |\n",
-          action.arguments
-          |> Enum.map(&argument_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(action.arguments, "", &argument_row/1),
           "\n\n"
         ]
       end
@@ -216,9 +214,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
       else
         [
           "## Changes\n\n",
-          changes
-          |> Enum.map(&format_change/1)
-          |> Enum.intersperse("\n"),
+          Enum.map_intersperse(changes, "\n", &format_change/1),
           "\n\n"
         ]
       end
@@ -331,9 +327,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
       else
         [
           "## Preparations\n\n",
-          preparations
-          |> Enum.map(&format_preparation/1)
-          |> Enum.intersperse("\n"),
+          Enum.map_intersperse(preparations, "\n", &format_preparation/1),
           "\n\n"
         ]
       end
@@ -487,16 +481,12 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
 
     @spec format_atom_list([atom()]) :: iodata()
     defp format_atom_list(list) do
-      list
-      |> Enum.map(&["`", to_string(&1), "`"])
-      |> Enum.intersperse(", ")
+      Enum.map_intersperse(list, ", ", &["`", to_string(&1), "`"])
     end
 
     @spec format_module_list([module()]) :: iodata()
     defp format_module_list(list) do
-      list
-      |> Enum.map(&inspect/1)
-      |> Enum.intersperse(", ")
+      Enum.map_intersperse(list, ", ", &inspect/1)
     end
 
     @spec clean_description(String.t() | nil) :: String.t()

--- a/lib/clarity/content/ash/aggregate_overview.ex
+++ b/lib/clarity/content/ash/aggregate_overview.ex
@@ -179,8 +179,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
 
     @spec format_relationship_path(list(atom()), Ash.Resource.t()) :: iodata()
     defp format_relationship_path(path, resource) when is_list(path) do
-      path
-      |> Enum.map(fn rel_name ->
+      Enum.map_intersperse(path, " → ", fn rel_name ->
         [
           "[`",
           to_string(rel_name),
@@ -189,7 +188,6 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           ")"
         ]
       end)
-      |> Enum.intersperse(" → ")
     end
 
     @spec format_field_link(atom(), list(atom()), Ash.Resource.t(), boolean()) :: iodata()
@@ -235,9 +233,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Join Filters\n\n",
           "| Relationship Path | Filter |\n",
           "| --- | --- |\n",
-          join_filters
-          |> Enum.map(&join_filter_row(&1, resource))
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(join_filters, "", &join_filter_row(&1, resource)),
           "\n\n"
         ]
       end
@@ -285,9 +281,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Return Type Constraints\n\n",
           "| Constraint | Value |\n",
           "| --- | --- |\n",
-          constraints
-          |> Enum.map(&constraint_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(constraints, "", &constraint_row/1),
           "\n\n"
         ]
       end

--- a/lib/clarity/content/ash/attribute_overview.ex
+++ b/lib/clarity/content/ash/attribute_overview.ex
@@ -133,9 +133,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Constraints\n\n",
           "| Constraint | Value |\n",
           "| --- | --- |\n",
-          constraints
-          |> Enum.map(&constraint_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(constraints, "", &constraint_row/1),
           "\n\n"
         ]
       end

--- a/lib/clarity/content/ash/calculation_overview.ex
+++ b/lib/clarity/content/ash/calculation_overview.ex
@@ -170,9 +170,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Arguments\n\n",
           "| Name | Type | Description | Required | Default |\n",
           "| --- | --- | --- | --- | --- |\n",
-          arguments
-          |> Enum.map(&argument_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(arguments, "", &argument_row/1),
           "\n\n"
         ]
       end
@@ -217,9 +215,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
         [
           "## Dependencies\n\n",
           "This calculation requires the following fields/relationships to be loaded:\n\n",
-          load
-          |> Enum.map(&format_dependency/1)
-          |> Enum.intersperse("\n"),
+          Enum.map_intersperse(load, "\n", &format_dependency/1),
           "\n\n"
         ]
       end
@@ -241,9 +237,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Return Type Constraints\n\n",
           "| Constraint | Value |\n",
           "| --- | --- |\n",
-          constraints
-          |> Enum.map(&constraint_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(constraints, "", &constraint_row/1),
           "\n\n"
         ]
       end

--- a/lib/clarity/content/ash/domain_overview.ex
+++ b/lib/clarity/content/ash/domain_overview.ex
@@ -68,9 +68,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Resources\n\n",
           "| Resource | Description |\n",
           "| --- | --- |\n",
-          resources
-          |> Enum.map(&resource_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(resources, "", &resource_row/1),
           "\n\n"
         ]
       end

--- a/lib/clarity/content/ash/policy_overview.ex
+++ b/lib/clarity/content/ash/policy_overview.ex
@@ -107,9 +107,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
 
     @spec format_condition([Check.ref()]) :: iodata()
     defp format_condition(condition) when is_list(condition) do
-      condition
-      |> Enum.map(&format_condition_item/1)
-      |> Enum.intersperse("\n")
+      Enum.map_intersperse(condition, "\n", &format_condition_item/1)
     end
 
     defp format_condition(condition) do
@@ -140,9 +138,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Checks\n\n",
           "| Type | Check | Description |\n",
           "| --- | --- | --- |\n",
-          checks
-          |> Enum.map(&check_row/1)
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(checks, "", &check_row/1),
           "\n\n"
         ]
       end

--- a/lib/clarity/content/ash/resource_overview.ex
+++ b/lib/clarity/content/ash/resource_overview.ex
@@ -95,9 +95,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Attributes\n\n",
           "| Name | Type | Description | Primary Key | Allow Nil | Public |\n",
           "| --- | --- | --- | --- | --- | --- |\n",
-          attributes
-          |> Enum.map(&attribute_row(&1, resource))
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(attributes, "", &attribute_row(&1, resource)),
           "\n\n"
         ]
       end
@@ -139,9 +137,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Relationships\n\n",
           "| Name | Type | Destination | Description |\n",
           "| --- | --- | --- | --- |\n",
-          relationships
-          |> Enum.map(&relationship_row(&1, resource))
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(relationships, "", &relationship_row(&1, resource)),
           "\n\n"
         ]
       end
@@ -184,9 +180,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
 
         [
           "## Actions\n\n",
-          grouped_actions
-          |> Enum.map(&action_group_section(&1, resource))
-          |> Enum.intersperse("\n"),
+          Enum.map_intersperse(grouped_actions, "\n", &action_group_section(&1, resource)),
           "\n\n"
         ]
       end
@@ -200,9 +194,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
         " Actions\n\n",
         "| Name | Description | Primary |\n",
         "| --- | --- | --- |\n",
-        actions
-        |> Enum.map(&action_row(&1, resource))
-        |> Enum.intersperse(""),
+        Enum.map_intersperse(actions, "", &action_row(&1, resource)),
         "\n"
       ]
     end
@@ -236,9 +228,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Aggregates\n\n",
           "| Name | Type | Field | Relationship |\n",
           "| --- | --- | --- | --- |\n",
-          aggregates
-          |> Enum.map(&aggregate_row(&1, resource))
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(aggregates, "", &aggregate_row(&1, resource)),
           "\n\n"
         ]
       end
@@ -281,9 +271,7 @@ with {:module, Ash} <- Code.ensure_loaded(Ash) do
           "## Calculations\n\n",
           "| Name | Type | Description |\n",
           "| --- | --- | --- |\n",
-          calculations
-          |> Enum.map(&calculation_row(&1, resource))
-          |> Enum.intersperse(""),
+          Enum.map_intersperse(calculations, "", &calculation_row(&1, resource)),
           "\n\n"
         ]
       end

--- a/lib/clarity/pages/page_live.html.heex
+++ b/lib/clarity/pages/page_live.html.heex
@@ -97,37 +97,44 @@
             prefix={@prefix}
             lens={@lens}
           />
-          <% {content_type, raw_content} = case @content && @content.render_static do
-            {:mermaid, content_fn} ->
-              props = %{
-                theme: @theme,
-                zoom_subgraph: data.zoom_graph,
-                zoom_level: @zoom_level,
-                shown_vertex_types: @shown_vertex_types,
-                available_vertex_types: @available_vertex_types
-              }
-              {"mermaid", IO.iodata_to_binary(content_fn.(props))}
-            {:viz, content_fn} ->
-              props = %{
-                theme: @theme,
-                zoom_subgraph: data.zoom_graph,
-                zoom_level: @zoom_level,
-                shown_vertex_types: @shown_vertex_types,
-                available_vertex_types: @available_vertex_types
-              }
-              {"graphviz", IO.iodata_to_binary(content_fn.(props))}
-            {:markdown, content_fn} ->
-              props = %{
-                theme: @theme,
-                zoom_subgraph: data.zoom_graph,
-                zoom_level: @zoom_level,
-                shown_vertex_types: @shown_vertex_types,
-                available_vertex_types: @available_vertex_types
-              }
-              {"markdown", IO.iodata_to_binary(content_fn.(props))}
-            _ ->
-              {"", ""}
-          end %>
+          <% {content_type, raw_content} =
+            case @content && @content.render_static do
+              {:mermaid, content_fn} ->
+                props = %{
+                  theme: @theme,
+                  zoom_subgraph: data.zoom_graph,
+                  zoom_level: @zoom_level,
+                  shown_vertex_types: @shown_vertex_types,
+                  available_vertex_types: @available_vertex_types
+                }
+
+                {"mermaid", IO.iodata_to_binary(content_fn.(props))}
+
+              {:viz, content_fn} ->
+                props = %{
+                  theme: @theme,
+                  zoom_subgraph: data.zoom_graph,
+                  zoom_level: @zoom_level,
+                  shown_vertex_types: @shown_vertex_types,
+                  available_vertex_types: @available_vertex_types
+                }
+
+                {"graphviz", IO.iodata_to_binary(content_fn.(props))}
+
+              {:markdown, content_fn} ->
+                props = %{
+                  theme: @theme,
+                  zoom_subgraph: data.zoom_graph,
+                  zoom_level: @zoom_level,
+                  shown_vertex_types: @shown_vertex_types,
+                  available_vertex_types: @available_vertex_types
+                }
+
+                {"markdown", IO.iodata_to_binary(content_fn.(props))}
+
+              _ ->
+                {"", ""}
+            end %>
           <.raw_content_drawer
             show={@show_raw_drawer && content_type != ""}
             content_type={content_type}

--- a/test/clarity/telemetry_test.exs
+++ b/test/clarity/telemetry_test.exs
@@ -184,8 +184,7 @@ defmodule Clarity.TelemetryTest do
 
       assert_receive {:telemetry, [:clarity, :worker, :start], _, %{clarity_server: ^mock_server}}
 
-      assert_receive {:telemetry, [:clarity, :worker, :stop], measurements,
-                      %{clarity_server: ^mock_server} = metadata}
+      assert_receive {:telemetry, [:clarity, :worker, :stop], measurements, %{clarity_server: ^mock_server} = metadata}
 
       assert %{result_entry_count: 1} = measurements
       assert %{result_type: :ok} = metadata
@@ -205,8 +204,7 @@ defmodule Clarity.TelemetryTest do
 
       assert_receive {:telemetry, [:clarity, :worker, :start], _, %{clarity_server: ^mock_server}}
 
-      assert_receive {:telemetry, [:clarity, :worker, :stop], measurements,
-                      %{clarity_server: ^mock_server} = metadata}
+      assert_receive {:telemetry, [:clarity, :worker, :stop], measurements, %{clarity_server: ^mock_server} = metadata}
 
       assert %{result_entry_count: nil} = measurements
       assert %{result_type: :unmet_dependencies} = metadata
@@ -223,8 +221,7 @@ defmodule Clarity.TelemetryTest do
       MockClarityServer.enqueue_pull_task(mock_server, {:ok, task})
       start_supervised!({Worker, clarity_server: mock_server})
 
-      assert_receive {:telemetry, [:clarity, :worker, :start], _,
-                      %{clarity_server: ^mock_server} = start_metadata},
+      assert_receive {:telemetry, [:clarity, :worker, :start], _, %{clarity_server: ^mock_server} = start_metadata},
                      500
 
       ref = start_metadata.telemetry_span_context
@@ -232,6 +229,7 @@ defmodule Clarity.TelemetryTest do
       assert_receive {:telemetry, [:clarity, :worker, :exception], measurements,
                       %{clarity_server: ^mock_server} = metadata},
                      500
+
       assert %{duration: _, monotonic_time: _, system_time: _} = measurements
 
       assert %{

--- a/test/mix/tasks/clarity.install_test.exs
+++ b/test/mix/tasks/clarity.install_test.exs
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Clarity.InstallTest do
   use ExUnit.Case, async: true
 
-  @moduletag :slow
-
   import Igniter.Test
+
+  @moduletag :slow
 
   test "installs clarity" do
     phx_test_project()


### PR DESCRIPTION
## Summary
- The CSS override from #103 used `:where()` selectors which have zero specificity and lose to the Typography plugin's `.prose code::before` rule
- Moves the fix to `tailwind.config.js` typography theme config, which suppresses the backtick pseudo-elements at the source
- Removes the ineffective CSS override from `app.css`