### PR TITLE
fix: LiveView 1.2.0-rc.0 compatibility

### DIFF
--- a/lib/clarity/components/editor_button_component.html.heex
+++ b/lib/clarity/components/editor_button_component.html.heex
@@ -1,6 +1,7 @@
 <div>
   <%= case @editor_action do %>
     <% :action_not_available -> %>
+      {""}
     <% :editor_not_available -> %>
       <button
         disabled


### PR DESCRIPTION
LiveView 1.2.0-rc.0 has a stricter EEx compiler that forbids cond fallbacks with no body. I used an empty string fallback. These changes are backwards compatible, so it works in all versions.