### PR TITLE
fix: configure `mdex_native` syntax highlighter for consumers

### DIFF
--- a/lib/clarity/components/markdown_component.ex
+++ b/lib/clarity/components/markdown_component.ex
@@ -12,10 +12,10 @@ defmodule Clarity.Components.MarkdownComponent do
   alias Phoenix.LiveView.Rendered
   alias Phoenix.LiveView.Socket
 
-  @mdex_opts [
-    extension: [table: true, strikethrough: true],
-    syntax_highlight: [formatter: {:html_linked, pre_class: "highlight"}]
-  ]
+  require Logger
+
+  @extension_opts [extension: [table: true, strikethrough: true]]
+  @highlight_opts [syntax_highlight: [formatter: {:html_linked, pre_class: "highlight"}]]
 
   attr :content, :any, required: true, doc: "The markdown content to render"
   attr :prefix, :string, required: true, doc: "URL prefix for link generation"
@@ -55,13 +55,48 @@ defmodule Clarity.Components.MarkdownComponent do
           lens :: Lens.t()
         ) :: String.t()
   defp parse_and_transform_markdown(content, prefix, lens) do
+    highlight_opts = highlight_opts()
+
     content
     |> IO.iodata_to_binary()
-    |> MDEx.parse_document!(@mdex_opts)
+    |> MDEx.parse_document!(@extension_opts ++ highlight_opts)
     |> MDEx.traverse_and_update(&transform_vertex_links(&1, prefix, lens))
-    |> MDEx.to_html!(syntax_highlight: @mdex_opts[:syntax_highlight])
+    |> MDEx.to_html!(highlight_opts)
   rescue
     _exception -> "<p>Error rendering markdown</p>"
+  end
+
+  # MDEx (>= 0.13) only highlights when `mdex_native` was compiled with Lumis,
+  # which is selected by the consuming app's compile-time config — a library
+  # cannot set it on their behalf. Without it, requesting the Lumis formatter
+  # raises, so we render unhighlighted instead and nudge towards the upgrade.
+  @spec highlight_opts() :: keyword()
+  defp highlight_opts do
+    if Application.get_env(:mdex_native, :syntax_highlighter) == :lumis do
+      @highlight_opts
+    else
+      warn_syntax_highlighting_disabled()
+      []
+    end
+  end
+
+  @spec warn_syntax_highlighting_disabled() :: :ok
+  defp warn_syntax_highlighting_disabled do
+    if :persistent_term.get({__MODULE__, :highlight_warning}, false) do
+      :ok
+    else
+      :persistent_term.put({__MODULE__, :highlight_warning}, true)
+
+      Logger.warning("""
+      Clarity: code blocks will render without syntax highlighting because \
+      `mdex_native` was compiled without Lumis support.
+
+      Run `mix igniter.upgrade clarity` to add the required configuration, or \
+      add it manually and recompile:
+
+          config :mdex_native, syntax_highlighter: :lumis
+      """)
+    end
   end
 
   @spec transform_vertex_links(MDEx.Document.md_node(), String.t(), Lens.t()) ::

--- a/lib/mix/tasks/clarity.install.ex
+++ b/lib/mix/tasks/clarity.install.ex
@@ -37,6 +37,7 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Code.List
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Application
+    alias Igniter.Project.Config
     alias Igniter.Project.Formatter
     alias Igniter.Project.MixProject
     alias Igniter.Project.Module
@@ -82,8 +83,17 @@ if Code.ensure_loaded?(Igniter) do
 
       igniter
       |> Formatter.import_dep(:clarity)
+      |> configure_syntax_highlighter()
       |> add_to_router(app_name, router)
       |> add_code_reloader()
+    end
+
+    # MDEx (>= 0.13) compiles syntax highlighting in via `mdex_native`'s
+    # compile-time config, which a library cannot set on a consumer's behalf.
+    # See Clarity.Components.MarkdownComponent for the runtime detection.
+    @spec configure_syntax_highlighter(igniter :: Igniter.t()) :: Igniter.t()
+    defp configure_syntax_highlighter(igniter) do
+      Config.configure_new(igniter, "config.exs", :mdex_native, [:syntax_highlighter], :lumis)
     end
 
     @spec add_to_router(igniter :: Igniter.t(), app_name :: atom(), router :: module() | nil) ::

--- a/lib/mix/tasks/clarity.upgrade.ex
+++ b/lib/mix/tasks/clarity.upgrade.ex
@@ -1,0 +1,82 @@
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Clarity.Upgrade do
+    @moduledoc false
+
+    use Igniter.Mix.Task
+
+    alias Igniter.Project.Config
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        # Groups allow for overlapping arguments for tasks by the same author
+        # See the generators guide for more.
+        group: :clarity,
+        # *other* dependencies to add
+        # i.e `{:foo, "~> 2.0"}`
+        adds_deps: [],
+        # *other* dependencies to add and call their associated installers, if they exist
+        # i.e `{:foo, "~> 2.0"}`
+        installs: [],
+        # a list of positional arguments, i.e `[:file]`
+        positional: [:from, :to],
+        # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
+        # This ensures your option schema includes options from nested tasks
+        composes: [],
+        # `OptionParser` schema
+        schema: [],
+        # Default values for the options in the `schema`
+        defaults: [],
+        # CLI aliases
+        aliases: [],
+        # A list of options in the schema that are required
+        required: []
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      positional = igniter.args.positional
+      options = igniter.args.options
+
+      upgrades =
+        %{
+          "0.6.0" => [&configure_syntax_highlighter/2]
+        }
+
+      # For each version that requires a change, add it to this map
+      # Each key is a version that points at a list of functions that take an
+      # igniter and options (i.e. flags or other custom options).
+      # See the upgrades guide for more.
+      Igniter.Upgrades.run(igniter, positional.from, positional.to, upgrades,
+        custom_opts: options
+      )
+    end
+
+    # MDEx (>= 0.13) compiles syntax highlighting in via `mdex_native`'s
+    # compile-time config, which a library cannot set on a consumer's behalf.
+    # See Clarity.Components.MarkdownComponent for the runtime detection.
+    @spec configure_syntax_highlighter(igniter :: Igniter.t(), options :: keyword()) ::
+            Igniter.t()
+    defp configure_syntax_highlighter(igniter, _options) do
+      Config.configure_new(igniter, "config.exs", :mdex_native, [:syntax_highlighter], :lumis)
+    end
+  end
+else
+  defmodule Mix.Tasks.Clarity.Upgrade do
+    @moduledoc false
+
+    use Mix.Task
+
+    @impl Mix.Task
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'clarity.upgrade' requires igniter. Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/mix/tasks/clarity.install_test.exs
+++ b/test/mix/tasks/clarity.install_test.exs
@@ -43,6 +43,11 @@ defmodule Mix.Tasks.Clarity.InstallTest do
        |end
        |
     """)
+    |> assert_has_patch("config/config.exs", """
+    ...|
+     + |config :mdex_native, syntax_highlighter: :lumis
+    ...|
+    """)
     |> apply_igniter!()
     |> Igniter.compose_task("clarity.install", [])
     |> assert_unchanged()

--- a/test/mix/tasks/clarity.upgrade_test.exs
+++ b/test/mix/tasks/clarity.upgrade_test.exs
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.Clarity.UpgradeTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  test "configures the mdex_native syntax highlighter when upgrading across 0.6.0" do
+    test_project()
+    |> Igniter.compose_task("clarity.upgrade", ["0.5.1", "0.6.0"])
+    |> assert_creates(
+      "config/config.exs",
+      "import Config\nconfig :mdex_native, syntax_highlighter: :lumis\n"
+    )
+  end
+
+  test "leaves an existing syntax highlighter choice untouched" do
+    [files: %{"config/config.exs" => "import Config\nconfig :mdex_native, syntax_highlighter: :syntect\n"}]
+    |> test_project()
+    |> Igniter.compose_task("clarity.upgrade", ["0.5.1", "0.6.0"])
+    |> assert_content_equals(
+      "config/config.exs",
+      "import Config\n\nconfig :mdex_native, syntax_highlighter: :syntect\n"
+    )
+  end
+
+  test "does nothing when the upgrade boundary is not crossed" do
+    test_project()
+    |> Igniter.compose_task("clarity.upgrade", ["0.6.0", "0.6.1"])
+    |> assert_unchanged("config/config.exs")
+  end
+end


### PR DESCRIPTION
## Problem

MDEx 0.13 makes Lumis syntax highlighting opt-in via `config :mdex_native, syntax_highlighter: :lumis`, which is read through `Application.compile_env/3` when `mdex_native` is compiled. That compile-time config selects which Rust feature is built into the NIF (and which precompiled variant is downloaded).

A library cannot set this on behalf of the apps that depend on it — `compile_env` reads the config of the *project being compiled* (the downstream app), and Clarity's own `config/config.exs` is never loaded for a consumer. So downstream consumers got a NIF with no highlighter compiled in, every fenced code block returned `:lumis_not_enabled` and raised, and the `rescue` in `MarkdownComponent` degraded the entire render to `<p>Error rendering markdown</p>`.

This is the exact downstream breakage that #107 pinned mdex to `0.12.x` to avoid; it resurfaced when the constraint was widened to `~> 0.13`.

## Changes

- **`clarity.install`** now writes `config :mdex_native, syntax_highlighter: :lumis` to the consumer's `config.exs` via `Igniter.Project.Config.configure_new/5`, so an existing `:syntect` choice is left untouched.
- **`clarity.upgrade`** — new Igniter upgrade task that adds the same config for existing installs upgrading across the release boundary.
- **`MarkdownComponent`** detects the highlighter at render time: when Lumis isn't enabled it renders code blocks **unhighlighted** (no crash, no error notice) and emits a one-time `Logger.warning` pointing at `mix igniter.upgrade clarity`.

The installer covers the Igniter happy path; the runtime guard makes manual installs and misconfigured setups degrade gracefully instead of erroring.

## Open questions for review

1. **Upgrade version key is `"0.6.0"`** — a guess, since the mdex-0.13 bump is unreleased (current version `0.5.1`). If this ships under a different version, the key in `clarity.upgrade.ex` needs to match the release.
2. **The warning says `mix igniter.upgrade clarity`, not `mix clarity.upgrade`** — a bare `mix clarity.upgrade` can't run (it has required `from`/`to` positionals). Happy to change the task shape if we want the shorter command to work.

## Tests

`clarity.upgrade` (apply / preserve existing choice / no-op outside boundary), an added config assertion + idempotency in the install test, and the existing 25 markdown tests. 31 passing.

The disabled render path has no automated test: exercising it requires flipping the global `:mdex_native` app env, which would race the `async: true` highlight assertions. Left out rather than introduce flakiness.